### PR TITLE
忽略未识别的Json key

### DIFF
--- a/app/src/main/java/com/tiyi/tiyi_app/application/TiYiApplication.kt
+++ b/app/src/main/java/com/tiyi/tiyi_app/application/TiYiApplication.kt
@@ -25,6 +25,10 @@ class TiyiApplication : Application() {
         initialize(this)
     }
 
+    val json = Json {
+        ignoreUnknownKeys = true
+    }
+
     private fun initialize(context: Context) {
         // 初始化 TokenManager
         TokenManager.init(context)
@@ -36,7 +40,7 @@ class TiyiApplication : Application() {
 
         // 创建 retrofitAuth 实例
         val retrofitAuth = Retrofit.Builder()
-            .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .baseUrl(getServiceUrl(this))
             .client(client)
             .build()


### PR DESCRIPTION
由于API同步工作还未完成，加上后续API也可能会修改，现在使用`ignoreUnknownKeys`保持兼容性